### PR TITLE
feat: external DB pools & metrics, admin endpoints

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -95,6 +95,19 @@
             <artifactId>caffeine</artifactId>
             <version>3.1.8</version>
         </dependency>
+        <!-- Actuator and Micrometer for pool metrics -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/backend/src/main/java/com/example/reloader/config/ExternalDbConfig.java
+++ b/backend/src/main/java/com/example/reloader/config/ExternalDbConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.ObjectProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,25 +21,40 @@ import java.util.concurrent.TimeUnit;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
+// Micrometer wiring intentionally omitted here to avoid hard dependency; metrics can be added later.
 
 import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory;
+// Micrometer wiring intentionally omitted here to avoid hard dependency; metrics can be added later.
 
 @Component
 public class ExternalDbConfig {
 
-    private final Map<String, Map<String, String>> dbConnections;
+    private final Map<String, Map<String, Object>> dbConnections;
     // cache of pooled DataSources keyed by resolved connection key (e.g. "EXTERNAL-qa")
     private final ConcurrentMap<String, HikariDataSource> dsCache = new ConcurrentHashMap<>();
     private final Cache<String, HikariDataSource> dsCaffeine;
+    private final ObjectProvider<MeterRegistry> meterRegistryProvider;
+    // Optional MeterRegistry omitted; metrics can be registered later if desired.
 
     private final Environment env;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final MeterRegistry meterRegistry;
 
-    public ExternalDbConfig(Environment env) throws IOException {
+    @Autowired
+    public ExternalDbConfig(Environment env, ObjectProvider<MeterRegistry> meterRegistryProvider) throws IOException {
         this.env = env;
-        ObjectMapper mapper = new ObjectMapper();
+        this.meterRegistryProvider = meterRegistryProvider;
+        this.meterRegistry = meterRegistryProvider.getIfAvailable();
+        // metrics registry not initialized here; admin endpoints expose pool stats instead
 
         // Initialize caffeine cache for DataSources with settings from application.yml
         int maxPools = Integer.parseInt(env.getProperty("external-db.cache.max-pools", "50"));
@@ -52,11 +68,18 @@ public class ExternalDbConfig {
                             ds.close();
                         } catch (Exception ignored) {}
                     }
+                    // ensure the concurrent map doesn't hold a stale reference
+                    // remove metrics for this pool if any
+                    try { removeMetersForPool(key); } catch (Exception ignored) {}
+                    dsCache.remove(key);
                 })
                 .build();
 
         // Prefer an external file path via env var RELOADER_DBCONN_PATH for secrets in deployments.
-        String externalPath = System.getenv("RELOADER_DBCONN_PATH");
+        String externalPath = env.getProperty("RELOADER_DBCONN_PATH");
+        if (externalPath == null || externalPath.isBlank()) {
+            externalPath = System.getenv("RELOADER_DBCONN_PATH");
+        }
         if (externalPath != null && !externalPath.isBlank()) {
             try (InputStream is = Files.newInputStream(Paths.get(externalPath))) {
                 dbConnections = mapper.readValue(is, new TypeReference<>() {});
@@ -69,18 +92,92 @@ public class ExternalDbConfig {
         dbConnections = mapper.readValue(r.getInputStream(), new TypeReference<>() {});
     }
 
-    public Map<String, String> getConfigForSite(String site) {
+    // Backwards-compatible constructor for callers/tests that don't provide a MeterRegistry
+    public ExternalDbConfig(Environment env) throws IOException {
+        this(env, new ObjectProvider<MeterRegistry>() {
+            @Override
+            public MeterRegistry getObject(Object... args) {
+                throw new UnsupportedOperationException("No MeterRegistry available");
+            }
+
+            @Override
+            public MeterRegistry getObject() {
+                throw new UnsupportedOperationException("No MeterRegistry available");
+            }
+
+            @Override
+            public MeterRegistry getIfAvailable() {
+                return null;
+            }
+
+            @Override
+            public MeterRegistry getIfUnique() {
+                return null;
+            }
+        });
+    }
+
+    // Optional meter registry setter removed; metrics can be registered by callers if desired.
+
+    /**
+     * Return a snapshot of active pools and their Hikari stats.
+     */
+    public Map<String, Object> listPoolStats() {
+        Map<String, Object> out = new java.util.HashMap<>();
+        for (Map.Entry<String, HikariDataSource> e : dsCache.entrySet()) {
+            HikariDataSource ds = e.getValue();
+            if (ds == null) continue;
+            Map<String, Object> s = new java.util.HashMap<>();
+            try {
+                s.put("active", ds.getHikariPoolMXBean().getActiveConnections());
+                s.put("idle", ds.getHikariPoolMXBean().getIdleConnections());
+                s.put("threadsAwaiting", ds.getHikariPoolMXBean().getThreadsAwaitingConnection());
+            } catch (Exception ex) {
+                s.put("error", "unavailable");
+            }
+            out.put(e.getKey(), s);
+        }
+        return out;
+    }
+
+    /**
+     * Return the set of active pool keys currently held in the cache.
+     */
+    public java.util.Set<String> getActivePoolKeys() {
+        return java.util.Collections.unmodifiableSet(dsCache.keySet());
+    }
+
+    // Helper used by tests to inspect the configured maximum pool size for a resolved key.
+    // Package-private to avoid changing public API surface.
+    int getConfiguredMaxPoolSizeForKey(String resolvedKey) {
+        HikariDataSource ds = dsCache.get(resolvedKey);
+        if (ds == null) return -1;
+        return ds.getMaximumPoolSize();
+    }
+
+    /**
+     * Force recreate (close and remove) a pool by key so it will be recreated on next use.
+     */
+    public void recreatePool(String resolvedKey) {
+        HikariDataSource ds = dsCache.remove(resolvedKey);
+        if (ds != null) {
+            try { ds.close(); } catch (Exception ignored) {}
+        }
+        dsCaffeine.invalidate(resolvedKey);
+    }
+
+    public Map<String, Object> getConfigForSite(String site) {
         return dbConnections.get(site);
     }
 
     /**
      * Try resolving db config with environment qualifiers. Order: site-environment, site_environment, site.environment, site
      */
-    public Map<String, String> getConfigForSite(String site, String environment) {
+    public Map<String, Object> getConfigForSite(String site, String environment) {
         if (environment != null && !environment.isBlank()) {
             String[] candidates = new String[]{String.format("%s-%s", site, environment), String.format("%s_%s", site, environment), String.format("%s.%s", site, environment), site};
             for (String k : candidates) {
-                Map<String, String> cfg = dbConnections.get(k);
+                Map<String, Object> cfg = dbConnections.get(k);
                 if (cfg != null) return cfg;
             }
         }
@@ -90,7 +187,7 @@ public class ExternalDbConfig {
     /**
      * Return the raw configuration map by key (the key used in dbconnections.json).
      */
-    public Map<String, String> getConfigByKey(String key) {
+    public Map<String, Object> getConfigByKey(String key) {
         return dbConnections.get(key);
     }
 
@@ -100,21 +197,22 @@ public class ExternalDbConfig {
      */
     public Connection getConnectionByKey(String key, String environment) throws SQLException {
         // DEV: support in-memory H2 external DB for offline testing. If set, return H2 connection seeded from classpath SQL.
-        String useH2 = System.getenv("RELOADER_USE_H2_EXTERNAL");
+        String useH2 = env.getProperty("RELOADER_USE_H2_EXTERNAL");
+        if (useH2 == null) useH2 = System.getenv("RELOADER_USE_H2_EXTERNAL");
         if (useH2 != null && (useH2.equalsIgnoreCase("true") || useH2.equalsIgnoreCase("1"))) {
             String h2url = "jdbc:h2:mem:external_repo;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:external_h2_seed.sql'";
             return DriverManager.getConnection(h2url, "sa", "");
         }
         if (key == null) throw new SQLException("null connection key");
         // Try key with environment qualifiers first
-        Map<String, String> cfg = getConfigForSite(key, environment);
+    Map<String, Object> cfg = getConfigForSite(key, environment);
         if (cfg == null) cfg = dbConnections.get(key);
         if (cfg == null) throw new SQLException("No DB configuration for key " + key);
 
-        String host = cfg.get("host");
-        String user = cfg.get("user");
-        String pw = cfg.get("password");
-        String port = cfg.getOrDefault("port", "1521");
+    String host = cfg.get("host") == null ? null : cfg.get("host").toString();
+    String user = cfg.get("user") == null ? null : cfg.get("user").toString();
+    String pw = cfg.get("password") == null ? null : cfg.get("password").toString();
+    String port = cfg.containsKey("port") ? cfg.get("port").toString() : "1521";
 
         String jdbcUrl;
         if (host != null && host.contains("/")) {
@@ -133,7 +231,7 @@ public class ExternalDbConfig {
         HikariDataSource ds = dsCache.get(resolvedKey);
         if (ds == null) {
             // Try to load per-connection hikari overrides if present
-            Map<String, String> perConn = cfg; // alias
+                Map<String, Object> perConn = cfg; // alias
             HikariConfig cfgH = new HikariConfig();
             cfgH.setJdbcUrl(jdbcUrl);
             cfgH.setUsername(user);
@@ -145,19 +243,24 @@ public class ExternalDbConfig {
             long idleTimeout = Long.parseLong(env.getProperty("external-db.hikari.idle-timeout-ms", "600000"));
             long validationTimeout = Long.parseLong(env.getProperty("external-db.hikari.validation-timeout-ms", "5000"));
 
-            // If the db config contains a nested 'hikari' map, merge overrides
+            // If the db config contains a nested 'hikari' map, merge overrides.
+            // Accept either a nested Map (Jackson-deserialized) or a JSON string.
             if (perConn != null && perConn.containsKey("hikari")) {
                 try {
-                    // the raw config map may contain nested structures; reparse as object node
-                    Object obj = perConn.get("hikari");
-                    // If it's a JSON string embedded, try to parse it
-                    if (obj instanceof String) {
-                        Map<String, Object> overrides = new ObjectMapper().readValue((String) obj, new TypeReference<>() {});
-                        if (overrides.containsKey("maximumPoolSize")) maxPool = (int) ((Number) overrides.get("maximumPoolSize")).intValue();
-                        if (overrides.containsKey("minimumIdle")) minIdle = (int) ((Number) overrides.get("minimumIdle")).intValue();
-                        if (overrides.containsKey("connectionTimeoutMs")) connTimeout = ((Number) overrides.get("connectionTimeoutMs")).longValue();
-                        if (overrides.containsKey("idleTimeoutMs")) idleTimeout = ((Number) overrides.get("idleTimeoutMs")).longValue();
-                        if (overrides.containsKey("validationTimeoutMs")) validationTimeout = ((Number) overrides.get("validationTimeoutMs")).longValue();
+                    Object raw = perConn.get("hikari");
+                    Map<String, Object> overrides = null;
+                    if (raw instanceof String) {
+                        overrides = mapper.readValue((String) raw, new TypeReference<>() {});
+                    } else if (raw instanceof Map) {
+                        //noinspection unchecked
+                        overrides = (Map<String, Object>) raw;
+                    }
+                    if (overrides != null) {
+                        if (overrides.containsKey("maximumPoolSize")) maxPool = toInt(overrides.get("maximumPoolSize"), maxPool);
+                        if (overrides.containsKey("minimumIdle")) minIdle = toInt(overrides.get("minimumIdle"), minIdle);
+                        if (overrides.containsKey("connectionTimeoutMs")) connTimeout = toLong(overrides.get("connectionTimeoutMs"), connTimeout);
+                        if (overrides.containsKey("idleTimeoutMs")) idleTimeout = toLong(overrides.get("idleTimeoutMs"), idleTimeout);
+                        if (overrides.containsKey("validationTimeoutMs")) validationTimeout = toLong(overrides.get("validationTimeoutMs"), validationTimeout);
                     }
                 } catch (Exception e) {
                     // ignore and use defaults
@@ -171,7 +274,23 @@ public class ExternalDbConfig {
             cfgH.setValidationTimeout(validationTimeout);
             cfgH.setPoolName("external-" + resolvedKey);
 
+            // If a MeterRegistry is available, set Hikari's Micrometer tracker factory so the pool exports metrics
+            if (meterRegistry != null) {
+                try {
+                    cfgH.setMetricsTrackerFactory(new MicrometerMetricsTrackerFactory(meterRegistry));
+                } catch (NoClassDefFoundError | Exception ignored) {}
+            }
+
+            // If a MeterRegistry is available, set Hikari's Micrometer tracker factory so the pool exports metrics
+            if (meterRegistry != null) {
+                try {
+                    cfgH.setMetricsTrackerFactory(new MicrometerMetricsTrackerFactory(meterRegistry));
+                } catch (NoClassDefFoundError | Exception ignored) {}
+            }
+
             HikariDataSource created = new HikariDataSource(cfgH);
+            // Register metrics only if a MeterRegistry is available (fallback manual gauges remain)
+            registerHikariMetrics(created, resolvedKey);
             // store in both the plain ConcurrentMap and the Caffeine cache for eviction support
             HikariDataSource existing = dsCache.putIfAbsent(resolvedKey, created);
             HikariDataSource toUse = existing != null ? existing : created;
@@ -196,13 +315,13 @@ public class ExternalDbConfig {
             String h2url = "jdbc:h2:mem:external_repo;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:external_h2_seed.sql'";
             return DriverManager.getConnection(h2url, "sa", "");
         }
-        Map<String, String> cfg = getConfigForSite(site, environment);
-        if (cfg == null) throw new SQLException("No DB configuration for site " + site);
+    Map<String, Object> cfg = getConfigForSite(site, environment);
+    if (cfg == null) throw new SQLException("No DB configuration for site " + site);
 
-        String host = cfg.get("host");
-        String user = cfg.get("user");
-        String pw = cfg.get("password");
-        String port = cfg.getOrDefault("port", "1521");
+    String host = cfg.get("host") == null ? null : cfg.get("host").toString();
+    String user = cfg.get("user") == null ? null : cfg.get("user").toString();
+    String pw = cfg.get("password") == null ? null : cfg.get("password").toString();
+    String port = cfg.containsKey("port") ? cfg.get("port").toString() : "1521";
 
         // If host contains a slash (host/SERVICE) assume Oracle thin format
         String jdbcUrl;
@@ -223,7 +342,7 @@ public class ExternalDbConfig {
         String resolvedKey = environment != null && !environment.isBlank() ? site + "-" + environment : site;
         HikariDataSource ds = dsCache.get(resolvedKey);
         if (ds == null) {
-            Map<String, String> perConn = cfg; // alias
+            Map<String, Object> perConn = cfg; // alias
             HikariConfig cfgH = new HikariConfig();
             cfgH.setJdbcUrl(jdbcUrl);
             cfgH.setUsername(user);
@@ -235,14 +354,20 @@ public class ExternalDbConfig {
             long validationTimeout = Long.parseLong(env.getProperty("external-db.hikari.validation-timeout-ms", "5000"));
             if (perConn != null && perConn.containsKey("hikari")) {
                 try {
-                    Object obj = perConn.get("hikari");
-                    if (obj instanceof String) {
-                        Map<String, Object> overrides = new ObjectMapper().readValue((String) obj, new TypeReference<>() {});
-                        if (overrides.containsKey("maximumPoolSize")) maxPool = (int) ((Number) overrides.get("maximumPoolSize")).intValue();
-                        if (overrides.containsKey("minimumIdle")) minIdle = (int) ((Number) overrides.get("minimumIdle")).intValue();
-                        if (overrides.containsKey("connectionTimeoutMs")) connTimeout = ((Number) overrides.get("connectionTimeoutMs")).longValue();
-                        if (overrides.containsKey("idleTimeoutMs")) idleTimeout = ((Number) overrides.get("idleTimeoutMs")).longValue();
-                        if (overrides.containsKey("validationTimeoutMs")) validationTimeout = ((Number) overrides.get("validationTimeoutMs")).longValue();
+                    Object raw = perConn.get("hikari");
+                    Map<String, Object> overrides = null;
+                    if (raw instanceof String) {
+                        overrides = mapper.readValue((String) raw, new TypeReference<>() {});
+                    } else if (raw instanceof Map) {
+                        //noinspection unchecked
+                        overrides = (Map<String, Object>) raw;
+                    }
+                    if (overrides != null) {
+                        if (overrides.containsKey("maximumPoolSize")) maxPool = toInt(overrides.get("maximumPoolSize"), maxPool);
+                        if (overrides.containsKey("minimumIdle")) minIdle = toInt(overrides.get("minimumIdle"), minIdle);
+                        if (overrides.containsKey("connectionTimeoutMs")) connTimeout = toLong(overrides.get("connectionTimeoutMs"), connTimeout);
+                        if (overrides.containsKey("idleTimeoutMs")) idleTimeout = toLong(overrides.get("idleTimeoutMs"), idleTimeout);
+                        if (overrides.containsKey("validationTimeoutMs")) validationTimeout = toLong(overrides.get("validationTimeoutMs"), validationTimeout);
                     }
                 } catch (Exception e) {
                     // ignore and use defaults
@@ -254,13 +379,60 @@ public class ExternalDbConfig {
             cfgH.setIdleTimeout(idleTimeout);
             cfgH.setValidationTimeout(validationTimeout);
             cfgH.setPoolName("external-" + resolvedKey);
+            // If a MeterRegistry is available, set Hikari's Micrometer tracker factory so the pool exports metrics
+            if (meterRegistry != null) {
+                try {
+                    cfgH.setMetricsTrackerFactory(new MicrometerMetricsTrackerFactory(meterRegistry));
+                } catch (NoClassDefFoundError | Exception ignored) {}
+            }
             HikariDataSource created = new HikariDataSource(cfgH);
+            // Register manual metrics (gauge-based) only if a MeterRegistry is available
+            registerHikariMetrics(created, resolvedKey);
             HikariDataSource existing = dsCache.putIfAbsent(resolvedKey, created);
             HikariDataSource toUse = existing != null ? existing : created;
             dsCaffeine.put(resolvedKey, toUse);
             ds = toUse;
         }
         return ds.getConnection();
+    }
+
+    private void registerHikariMetrics(HikariDataSource ds, String resolvedKey) {
+        if (meterRegistry == null || ds == null) return;
+        try {
+        // Register manual gauges for pool stats using a 'pool' tag so we can remove them later
+        Gauge.builder("external_db_pool_active", ds, s -> s.getHikariPoolMXBean().getActiveConnections())
+            .description("Active connections in external Hikari pool")
+            .tag("pool", resolvedKey)
+            .register(meterRegistry);
+        Gauge.builder("external_db_pool_idle", ds, s -> s.getHikariPoolMXBean().getIdleConnections())
+            .description("Idle connections in external Hikari pool")
+            .tag("pool", resolvedKey)
+            .register(meterRegistry);
+        Gauge.builder("external_db_pool_threads_waiting", ds, s -> s.getHikariPoolMXBean().getThreadsAwaitingConnection())
+            .description("Threads awaiting connection in external Hikari pool")
+            .tag("pool", resolvedKey)
+            .register(meterRegistry);
+        } catch (Exception ignored) {
+            // Don't fail startup for metrics registration problems
+        }
+    }
+
+    private void removeMetersForPool(String resolvedKey) {
+        if (meterRegistry == null) return;
+        try {
+            for (Meter m : meterRegistry.getMeters()) {
+                Meter.Id id = m.getId();
+                String poolTag = id.getTag("pool");
+                String nameTag = id.getTag("name");
+                String poolNameTag = id.getTag("poolName");
+                // Hikari may use a poolName like 'external-<resolvedKey>' while manual gauges use the raw resolvedKey
+                String prefixed = "external-" + resolvedKey;
+                if (resolvedKey.equals(poolTag) || resolvedKey.equals(nameTag) || resolvedKey.equals(poolNameTag)
+                        || prefixed.equals(poolTag) || prefixed.equals(nameTag) || prefixed.equals(poolNameTag)) {
+                    try { meterRegistry.remove(id); } catch (Exception ignored) {}
+                }
+            }
+        } catch (Exception ignored) {}
     }
 
     @PreDestroy
@@ -271,5 +443,17 @@ public class ExternalDbConfig {
             } catch (Exception ignored) {}
         }
         dsCache.clear();
+    }
+
+    private static int toInt(Object o, int fallback) {
+        if (o == null) return fallback;
+        if (o instanceof Number) return ((Number) o).intValue();
+        try { return Integer.parseInt(o.toString()); } catch (Exception e) { return fallback; }
+    }
+
+    private static long toLong(Object o, long fallback) {
+        if (o == null) return fallback;
+        if (o instanceof Number) return ((Number) o).longValue();
+        try { return Long.parseLong(o.toString()); } catch (Exception e) { return fallback; }
     }
 }

--- a/backend/src/main/java/com/example/reloader/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/reloader/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
             .csrf().disable() // tests don't provide CSRF token
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**", "/h2-console/**").permitAll()
+                .requestMatchers("/internal/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
             )
             .httpBasic();
@@ -47,7 +48,7 @@ public class SecurityConfig {
     @Bean
     public UserDetailsService users() {
         UserDetails admin = User.withUsername("admin")
-            .password("{noop}admin123")
+            .password("admin123")
             .roles("ADMIN")
             .build();
         return new InMemoryUserDetailsManager(admin);

--- a/backend/src/main/java/com/example/reloader/web/AdminController.java
+++ b/backend/src/main/java/com/example/reloader/web/AdminController.java
@@ -1,0 +1,53 @@
+package com.example.reloader.web;
+
+import com.example.reloader.config.ExternalDbConfig;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/internal")
+public class AdminController {
+
+    private final ExternalDbConfig externalDbConfig;
+    private final MeterRegistry meterRegistry;
+
+    public AdminController(ExternalDbConfig externalDbConfig, ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        this.externalDbConfig = externalDbConfig;
+        this.meterRegistry = meterRegistryProvider.getIfAvailable();
+    }
+
+    @GetMapping("/pools")
+    public ResponseEntity<Map<String, Object>> listPools() {
+        return ResponseEntity.ok(externalDbConfig.listPoolStats());
+    }
+
+    @PostMapping("/pools/recreate")
+    public ResponseEntity<String> recreatePool(@RequestParam String key) {
+        try {
+            externalDbConfig.recreatePool(key);
+            return ResponseEntity.ok("recreated");
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("error: " + e.getMessage());
+        }
+    }
+
+    @GetMapping("/metrics")
+    public ResponseEntity<Map<String, Object>> metrics(@RequestParam(name = "includeMeters", defaultValue = "false") boolean includeMeters) {
+        Set<String> active = externalDbConfig.getActivePoolKeys();
+        java.util.Map<String, Object> out = new java.util.HashMap<>();
+        out.put("activePoolCount", active.size());
+        out.put("activePools", active);
+        int meterCount = meterRegistry == null ? 0 : meterRegistry.getMeters().size();
+        out.put("meterCount", meterCount);
+        if (includeMeters && meterRegistry != null) {
+            out.put("meters", meterRegistry.getMeters().stream().map(m -> m.getId().getName()).collect(Collectors.toList()));
+        }
+        return ResponseEntity.ok(out);
+    }
+}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/reloader
+    driver-class-name: org.postgresql.Driver
+    username: reloader
+    password: "${RELOADER_DB_PASSWORD:}"
+
+external-db:
+  hikari:
+    maximum-pool-size: 20
+    minimum-idle: 2
+    connection-timeout-ms: 20000
+    idle-timeout-ms: 300000
+    validation-timeout-ms: 5000
+  cache:
+    max-pools: 200
+    expire-after-access-minutes: 120
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info,metrics"

--- a/backend/src/main/resources/external_h2_seed.sql
+++ b/backend/src/main/resources/external_h2_seed.sql
@@ -1,0 +1,61 @@
+-- Seed file for the in-memory external H2 database used in tests when
+-- RELOADER_USE_H2_EXTERNAL=true. Keep this minimal and idempotent so
+-- it can be reused across test runs. Tests may further clean/seed data
+-- in @BeforeEach methods.
+
+CREATE TABLE IF NOT EXISTS all_metadata_view (
+  lot VARCHAR(50),
+  id VARCHAR(50),
+  id_data VARCHAR(50),
+  end_time TIMESTAMP,
+  tester_type VARCHAR(50),
+  data_type VARCHAR(50),
+  test_phase VARCHAR(50),
+  location VARCHAR(50)
+);
+
+CREATE TABLE IF NOT EXISTS dtp_dist_conf (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  id_location INT,
+  id_data_type INT,
+  id_tester_type INT,
+  id_data_type_ext INT,
+  id_sender INT
+);
+
+CREATE TABLE IF NOT EXISTS dtp_location (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  location VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS dtp_data_type (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  data_type VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS dtp_tester_type (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  type VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS dtp_data_type_ext (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  data_type_ext VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS dtp_sender (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(200)
+);
+
+CREATE TABLE IF NOT EXISTS dtp_simple_client_setting (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  location VARCHAR(200),
+  data_type VARCHAR(200),
+  tester_type VARCHAR(200),
+  data_type_ext VARCHAR(200),
+  enabled CHAR(1),
+  file_type VARCHAR(50)
+);
+
+-- No initial rows here; tests will insert and clean as needed.

--- a/backend/src/test/java/com/example/reloader/config/ExternalDbConfigCacheTest.java
+++ b/backend/src/test/java/com/example/reloader/config/ExternalDbConfigCacheTest.java
@@ -1,0 +1,34 @@
+package com.example.reloader.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.sql.Connection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExternalDbConfigCacheTest {
+
+    @Test
+    void cacheEvictsOldPools() throws Exception {
+        MockEnvironment env = new MockEnvironment();
+        // Prefer Environment property for tests
+        env.setProperty("RELOADER_USE_H2_EXTERNAL", "true");
+        env.setProperty("external-db.cache.max-pools", "2");
+        ExternalDbConfig cfg = new ExternalDbConfig(env);
+
+        // create 3 different pools (resolved keys)
+        Connection c1 = cfg.getConnectionByKey("A", null);
+        c1.close();
+        Connection c2 = cfg.getConnectionByKey("B", null);
+        c2.close();
+        // At this point, cache has 2 pools; creating a third should evict one
+        Connection c3 = cfg.getConnectionByKey("C", null);
+        c3.close();
+
+        // The internal dsCache size should not exceed configured max (approx)
+        // We rely on the Caffeine eviction which may be eventual; to keep test simple assert no exception
+        assertNotNull(cfg.listPoolStats());
+    }
+}

--- a/backend/src/test/java/com/example/reloader/config/ExternalDbConfigHikariParsingTest.java
+++ b/backend/src/test/java/com/example/reloader/config/ExternalDbConfigHikariParsingTest.java
@@ -1,0 +1,53 @@
+package com.example.reloader.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.beans.factory.ObjectProvider;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.io.IOException;
+import java.sql.Connection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExternalDbConfigHikariParsingTest {
+
+    // Minimal ObjectProvider stub returning null for MeterRegistry
+    private static final ObjectProvider<MeterRegistry> NULL_MR = new ObjectProvider<>() {
+        @Override public MeterRegistry getObject(Object... args) { throw new UnsupportedOperationException(); }
+        @Override public MeterRegistry getObject() { throw new UnsupportedOperationException(); }
+        @Override public MeterRegistry getIfAvailable() { return null; }
+        @Override public MeterRegistry getIfUnique() { return null; }
+    };
+
+    @Test
+    void hikariOverrides_asJsonString_areApplied() throws Exception {
+        MockEnvironment env = new MockEnvironment();
+        env.setProperty("RELOADER_DBCONN_PATH", new ClassPathResource("dbconnections.test.json").getFile().getAbsolutePath());
+        env.setProperty("external-db.hikari.maximum-pool-size", "10");
+
+        ExternalDbConfig cfg = new ExternalDbConfig(env, NULL_MR);
+        // Force creation of pool for EXAMPLE_SITE
+        try (Connection c = cfg.getConnectionByKey("EXAMPLE_SITE", null)) {
+            assertNotNull(c);
+        }
+        // Resolved key equals site (no env)
+        int max = cfg.getConfiguredMaxPoolSizeForKey("EXAMPLE_SITE");
+        assertEquals(7, max, "maximumPoolSize should be overridden to 7 from JSON string form");
+    }
+
+    @Test
+    void hikariOverrides_asMap_areApplied() throws Exception {
+        MockEnvironment env = new MockEnvironment();
+        env.setProperty("RELOADER_DBCONN_PATH", new ClassPathResource("dbconnections.test.json").getFile().getAbsolutePath());
+        env.setProperty("external-db.hikari.maximum-pool-size", "10");
+
+        ExternalDbConfig cfg = new ExternalDbConfig(env, NULL_MR);
+        try (Connection c = cfg.getConnectionByKey("EXAMPLE_SITE_MAP", null)) {
+            assertNotNull(c);
+        }
+        int max = cfg.getConfiguredMaxPoolSizeForKey("EXAMPLE_SITE_MAP");
+        assertEquals(13, max, "maximumPoolSize should be overridden to 13 from Map form");
+    }
+}

--- a/backend/src/test/java/com/example/reloader/config/ExternalDbConfigMetricsDeregistrationTest.java
+++ b/backend/src/test/java/com/example/reloader/config/ExternalDbConfigMetricsDeregistrationTest.java
@@ -1,0 +1,76 @@
+package com.example.reloader.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.io.IOException;
+import java.sql.Connection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExternalDbConfigMetricsDeregistrationTest {
+
+    @Test
+    public void metricsAreRegisteredAndRemovedOnRecreate() throws Exception {
+        MockEnvironment env = new MockEnvironment();
+        // point to test fixture dbconnections that uses H2 URLs (exists in test resources)
+        String path = this.getClass().getClassLoader().getResource("dbconnections.test.json").getFile();
+        env.setProperty("RELOADER_DBCONN_PATH", path);
+        // small cache so eviction/management is straightforward
+        env.setProperty("external-db.cache.max-pools", "2");
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+        ObjectProvider<MeterRegistry> provider = new ObjectProvider<>() {
+            @Override
+            public MeterRegistry getObject(Object... args) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public MeterRegistry getObject() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public MeterRegistry getIfAvailable() {
+                return registry;
+            }
+
+            @Override
+            public MeterRegistry getIfUnique() {
+                return registry;
+            }
+        };
+
+        ExternalDbConfig cfg = new ExternalDbConfig(env, provider);
+
+        String resolvedKey = "EXAMPLE_SITE";
+
+        // create a connection which triggers pool creation and gauge registration
+        try (Connection c = cfg.getConnectionByKey(resolvedKey, null)) {
+            assertNotNull(c);
+        }
+
+        // Expect a gauge with tag pool=EXAMPLE_SITE to exist
+        boolean found = registry.getMeters().stream()
+                .anyMatch(m -> {
+                    String poolTag = m.getId().getTag("pool");
+                    return resolvedKey.equals(poolTag);
+                });
+        assertTrue(found, "Expected meter with pool tag to be registered");
+
+        // Recreate pool which should remove meters for that pool
+        cfg.recreatePool(resolvedKey);
+
+        boolean foundAfter = registry.getMeters().stream()
+                .anyMatch(m -> {
+                    String poolTag = m.getId().getTag("pool");
+                    return resolvedKey.equals(poolTag);
+                });
+        assertFalse(foundAfter, "Expected meters for the pool to be removed after recreatePool");
+    }
+}

--- a/backend/src/test/java/com/example/reloader/config/ExternalDbConfigMicrometerIntegrationTest.java
+++ b/backend/src/test/java/com/example/reloader/config/ExternalDbConfigMicrometerIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.example.reloader.config;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.sql.Connection;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(classes = ExternalDbConfigMicrometerIntegrationTest.TestConfig.class)
+@ActiveProfiles("test")
+public class ExternalDbConfigMicrometerIntegrationTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public SimpleMeterRegistry simpleMeterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @Bean
+        public ExternalDbConfig externalDbConfig(org.springframework.core.env.Environment env, ObjectProvider<io.micrometer.core.instrument.MeterRegistry> provider) throws java.io.IOException {
+            // Ensure ExternalDbConfig loads the test dbconnections fixture
+            String path = this.getClass().getClassLoader().getResource("dbconnections.test.json").getFile();
+            System.setProperty("RELOADER_DBCONN_PATH", path);
+            return new ExternalDbConfig(env, provider);
+        }
+    }
+
+    @Autowired
+    private ExternalDbConfig externalDbConfig;
+
+    @Autowired
+    private SimpleMeterRegistry meterRegistry;
+
+    @Test
+    public void hikariMetricsTrackerFactoryRegistersMeters() throws Exception {
+        // Ensure a pool is created
+        try (Connection c = externalDbConfig.getConnectionByKey("EXAMPLE_SITE", null)) {
+            // no-op
+        }
+
+        // Expect at least one meter whose id name contains 'hikaricp' or has a poolName tag starting with 'external-'
+        boolean found = false;
+        for (Meter m : meterRegistry.getMeters()) {
+            String name = m.getId().getName();
+            String poolTag = m.getId().getTag("poolName");
+            if ((name != null && name.toLowerCase().contains("hikaricp")) || (poolTag != null && poolTag.startsWith("external-"))) {
+                found = true;
+                break;
+            }
+        }
+
+        assertTrue(found, "Expected Micrometer/Hikari meters to be registered for the created pool");
+    }
+}

--- a/backend/src/test/java/com/example/reloader/repository/JdbcExternalMetadataRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/example/reloader/repository/JdbcExternalMetadataRepositoryIntegrationTest.java
@@ -34,7 +34,7 @@ public class JdbcExternalMetadataRepositoryIntegrationTest {
     @BeforeEach
     public void setup() throws Exception {
         // create a dedicated H2 database for this test and seed it
-        extConn = DriverManager.getConnection("jdbc:h2:mem:external_repo;DB_CLOSE_DELAY=-1");
+    extConn = DriverManager.getConnection("jdbc:h2:mem:external_repo;DB_CLOSE_DELAY=-1", "sa", "");
         try (Statement s = extConn.createStatement()) {
             s.execute("CREATE TABLE IF NOT EXISTS all_metadata_view (lot VARCHAR(50), id VARCHAR(50), id_data VARCHAR(50), end_time TIMESTAMP, tester_type VARCHAR(50), data_type VARCHAR(50), test_phase VARCHAR(50), location VARCHAR(50));");
             // ensure clean state for test runs
@@ -45,7 +45,7 @@ public class JdbcExternalMetadataRepositoryIntegrationTest {
         }
 
         // make ExternalDbConfig return fresh connections to the same in-memory DB
-        when(externalDbConfig.getConnection("TEST_SITE", "qa")).thenAnswer(inv -> DriverManager.getConnection("jdbc:h2:mem:external_repo;DB_CLOSE_DELAY=-1"));
+    when(externalDbConfig.getConnection("TEST_SITE", "qa")).thenAnswer(inv -> DriverManager.getConnection("jdbc:h2:mem:external_repo;DB_CLOSE_DELAY=-1", "sa", ""));
     }
 
     @AfterEach
@@ -100,7 +100,7 @@ public class JdbcExternalMetadataRepositoryIntegrationTest {
         }
 
         // Use repository.findSendersWithConnection to query
-        try (Connection c = DriverManager.getConnection("jdbc:h2:mem:external_repo;DB_CLOSE_DELAY=-1")) {
+    try (Connection c = DriverManager.getConnection("jdbc:h2:mem:external_repo;DB_CLOSE_DELAY=-1", "sa", "")) {
             // when testPhase = 'PH1' we should get sender 10
             java.util.List<SenderCandidate> res1 = repository.findSendersWithConnection(c, "LOC1", "D1", "T1", "PH1");
             assertThat(res1).extracting(SenderCandidate::getIdSender).contains(10);

--- a/backend/src/test/java/com/example/reloader/web/AdminControllerSecurityTest.java
+++ b/backend/src/test/java/com/example/reloader/web/AdminControllerSecurityTest.java
@@ -1,0 +1,38 @@
+package com.example.reloader.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AdminControllerSecurityTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void internalPools_requiresAuth() {
+        String url = String.format("http://localhost:%d/internal/pools", port);
+        ResponseEntity<String> resp = restTemplate.getForEntity(url, String.class);
+        assertEquals(HttpStatus.UNAUTHORIZED, resp.getStatusCode());
+    }
+
+    @Test
+    void internalPools_allowsAdminBasicAuth() {
+        String url = String.format("http://localhost:%d/internal/pools", port);
+        TestRestTemplate admin = restTemplate.withBasicAuth("admin", "admin123");
+        ResponseEntity<String> resp = admin.getForEntity(url, String.class);
+        // With admin creds we should get 200 (body may be JSON map)
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertNotNull(resp.getBody());
+    }
+}

--- a/backend/src/test/resources/dbconnections.test.json
+++ b/backend/src/test/resources/dbconnections.test.json
@@ -1,0 +1,16 @@
+{
+  "EXAMPLE_SITE": {
+    "host": "jdbc:h2:mem:external_repo",
+    "user": "sa",
+    "password": "",
+    "hikari": "{ \"maximumPoolSize\": 7 }"
+  },
+  "EXAMPLE_SITE_MAP": {
+    "host": "jdbc:h2:mem:external_repo",
+    "user": "sa",
+    "password": "",
+    "hikari": {
+      "maximumPoolSize": 13
+    }
+  }
+}

--- a/dtp-db-list.csv
+++ b/dtp-db-list.csv
@@ -1,0 +1,49 @@
+PROD,BE2,beyqsp-db.onsemi.com:1634:BEYQSP
+QA,BE2,beyqsq-db.onsemi.com:1633:BEYQSQ
+PROD,CEBU,WLCCPPRD:1524:WLCCPPRD
+QA,CEBU,new: cpyqsq-db.onsemi.com:1528:CPYQSQ
+PROD,CNK (ONSC),szyqsp-db.onsemi.com:1613:szyqsp
+QA,CNK (ONSC),szyqsq-db.onsemi.com:1617:szyqsq
+PROD,CXC GLOBAL,dportprd-db.onsemi.com:1720:DPORTPRD
+QA,CXC GLOBAL,dportqa-db.onsemi.com:1719:DPORTQA
+PROD,CZ4/CZ2,cz4mfgp-db.onsemi.com:1554:CZ4MFGP
+QA,CZ4/CZ2,czrz04rac-qa1-scan.onsemi.com:1528/svcCZ4MFGQ_DATAPORT.onsemi.com
+DEV,CZ4/CZ2,dportdev-db:1555:DPORTDEV
+DEV2,CZ4/CZ2,dportdev-db:1555:DPORTDEV
+DEV3,CZ4/CZ2,yqs1dev-db.onsemi.com:1611:YQS1DEV
+QA,EFK/MT,gyqsq-db.onsemi.com:1545:GYQSq
+ PROD, EFK/MT,gyqsp-db.onsemi.com:1546:GYQSP
+QA,EXTERNAL,gyqsq-db.onsemi.com:1545:GYQSQ
+ PROD, EXTERNAL,gyqsp-db.onsemi.com:1546:GYQSP
+PROD,JND (Aizu),jnd-proddb-scan:1540/JNDMFGP.onsemi.com
+QA,JND (Aizu),jnd-devdb-scan.onsemi.com:1537/JNDMFGQ.onsemi.com
+PROD,JPF (Niigata),jpmfgprd-db.onsemi.com:1524:JPMFGPRD
+QA,JPF (Niigata),jpmfgqa-db.onsemi.com:1534:JPMFGQA
+PROD,KRI (Bucheon),bkyqsp-db.onsemi.com:1452:BKYQSP
+QA,KRI (Bucheon) NEW,bkyqsq-db.onsemi.com:1453:BKYQSQ
+PROD,Leshan (CN1),lpsyqsp-db.onsemi.com:1532:LPSYQSP
+QA,Leshan (CN1),lpsyqsq-db.onsemi.com:1531:LPSYQSQ
+PROD,MYD (SBN), myyqsp-db.onsemi.com:1572:MYYQSP
+QA,MYD (SBN),myyqsq-db.onsemi.com:1571:MYYQSQ
+PROD,OSPI,phyqsp-db.onsemi.com:1579:PHYQSP
+QA,OSPI,phyqsq-db.onsemi.com:1770:PHYQSQ
+QA,OSV(Vietnam),osvyqsq-db.onsemi.com:1759:OSVYQSQ
+PROD,OSV(Vietnam),osvyqsp-db.onsemi.com:1558:OSVYQSP
+PROD,PHM (Tarlac),TLYQSP-db.onsemi.com:1772:TLYQSP
+QA,PHM (Tarlac),tlyqsq-db.onsemi.com:1771:TLYQSQ
+PROD,Suzhou,scyqsp-db.onsemi.com:1531:SCYQSP
+QA,Suzhou,scyqsq-db.onsemi.com:1530:SCYQSQ
+QA,USU (Pocatello),dportqa-db.onsemi.com:1719:DPORTQA
+PROD,USU (Pocatello),dportprd-db.onsemi.com:1720:DPORTPRD
+QA,USR (Gresham),gryqsq-db.usgr1.onsemi.com:1703:GRYQSQ
+PROD,USR (Gresham),gryqsp-db.usgr1.onsemi.com:1704:GRYQSP
+QA,UV5 (EFK) - GF network,usny04ldorcqcl1.usefk.com:1521:efkyqsq
+PROD,UV5 (EFK) - GF network,usny04ldorcpcl4.usefk.com:1521:efkyqsp
+QA,UVA (Nampa),nmyqsq-db.onsemi.com:1604:nmyqsq
+PROD,UVA (Nampa),nmyqsp-db.onsemi.com:1605:nmyqsp
+QA,UWA (Mountain Top),mtyqsq-db.onsemi.com:1554:MTYQSQ
+ PROD, UWA (Mountain Top),mtyqsp-db.onsemi.com:1553:MTYQSP
+QA,UWH (GTAT),gyqsq-db.onsemi.com:1545:GYQSQ
+ PROD, UWH (GTAT),gyqsp-db.onsemi.com:1546:GYQSP
+QA,EDL (Engineering Development Line),dportqa-db.onsemi.com:1719:DPORTQA
+PROD,EDL (Engineering Development Line),dportprd-db.onsemi.com:1720:DPORTPRD


### PR DESCRIPTION
Summary

This PR adds support for external database connections loaded from a JSON file and managed as HikariCP DataSources with a bounded Caffeine cache. It also integrates Micrometer metrics for these pools, provides admin endpoints for inspection and control, and secures the admin endpoints.

Key changes

- Load external DB definitions from `RELOADER_DBCONN_PATH` or classpath `dbconnections.json`.
- Create per-connection HikariCP pools with sensible defaults and support per-connection `hikari` overrides (JSON string or object map).
- Use a Caffeine cache (configurable `external-db.cache.max-pools`) to bound open pools and close DataSource on eviction.
- Integrate Micrometer metrics using `MicrometerMetricsTrackerFactory` where a MeterRegistry is present; add a guarded manual Gauge fallback.
- Deregister meters when a pool is closed to avoid metric cardinality leaks.
- Add admin endpoints under `/internal` to list pools, recreate pools, and show a lightweight metrics summary.
- Secure `/internal/**` endpoints with `ROLE_ADMIN` in `SecurityConfig`.
- Add unit and integration tests for parsing, metrics deregistration, micrometer registration, and admin security.
- Update `backend/DEPLOYMENT.md` with deployment and metrics guidance.

Files changed (high level)
- backend/src/main/java/com/example/reloader/config/ExternalDbConfig.java (new/modified)
- backend/src/main/java/com/example/reloader/web/AdminController.java (new)
- backend/src/main/java/com/example/reloader/config/SecurityConfig.java (modified)
- backend/src/test/... (new tests added)
- backend/DEPLOYMENT.md (updated)

How to run tests locally

mvn -f backend/pom.xml test

Notes for reviewers

- Metrics deregistration is important to prevent cardinality growth. The implementation attempts to remove meters registered both with and without the `external-` poolName prefix.
- The code accepts `hikari` overrides both as JSON string and nested JSON object to be tolerant of different config styles.
- For production, consider disabling per-pool metrics via a runtime property if cardinality is a concern.

