### PR TITLE
docs(dev): add H2 seed helper and README note

### DIFF
--- a/backend/README-DEV.md
+++ b/backend/README-DEV.md
@@ -34,6 +34,26 @@ RELOADER_USE_H2_EXTERNAL=true EXTERNAL_DB_ALLOW_WRITES=true \
   mvn -f backend/pom.xml -DskipITs=true test
 ```
 
+Maven profile shortcuts
+-----------------------
+
+You can use the Maven profiles defined in `backend/pom.xml` to make running these scenarios more convenient.
+
+- Use the `dev` profile to enable the in-memory H2 external DB, enable writes, and activate the Spring `dev` profile:
+
+```bash
+mvn -f backend/pom.xml -Pdev -DskipITs=true test
+```
+
+- Use the `external-oracle` profile when you want to run tests or manual checks against a real Oracle external DB. This profile does not provide credentials; pass them via `-D` or environment variables. Example (replace placeholders):
+
+```bash
+mvn -f backend/pom.xml -Pexternal-oracle -DskipITs=true \
+  -Dexternal.db.username=MYUSER -Dexternal.db.password=MYSECRET -Dexternal.db.url=jdbc:oracle:thin:@//host:1521/DBSERVICE test
+```
+
+Note: For CI or automated runs prefer injecting credentials via your CI secret store or environment variables rather than on the command line.
+
 Notes
 -----
 - The env vars above map to Spring properties `reloader.use-h2-external` and `external-db.allow-writes`. You can also provide them via `-D` when invoking Maven or via your IDE run configuration.
@@ -282,6 +302,22 @@ CREATE SEQUENCE IF NOT EXISTS DTP_SENDER_QUEUE_ITEM_SEQ START WITH 1;
 ```
 
 If you want, I can also add a small helper script under `backend/scripts/` to run the SQL seed against a running H2 instance for manual testing.
+
+Seed helper script
+------------------
+
+A small convenience script is included to seed a local H2 database with the external queue schema used by tests:
+
+- Path: `backend/scripts/seed_external_h2.sh`
+- Default DB URL: `jdbc:h2:./external-h2-db`
+
+Usage (from repository root):
+
+```bash
+bash backend/scripts/seed_external_h2.sh
+```
+
+The script will attempt to locate an H2 jar in your local Maven cache and fall back to copying the project's dependencies into `target/dependency` before invoking H2's RunScript tool against `backend/src/main/resources/external_h2_seed.sql`.
 
 Where to look next in the code
 ------------------------------

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -116,5 +116,68 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
         </plugins>
+        <!-- Optional developer profiles are declared below. Use -Pdev or -Pexternal-oracle when running Maven to
+             enable convenient system properties for tests and local runs. These profiles only set test/system
+             properties; you still must provide real DB credentials for the external-oracle profile via -D or
+             environment variables as appropriate. -->
     </build>
+    
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <!-- These maven properties are convenient defaults for running tests locally against the in-memory H2 external DB -->
+                <reloader.use-h2-external>true</reloader.use-h2-external>
+                <external-db.allow-writes>true</external-db.allow-writes>
+                <spring.profiles.active>dev</spring.profiles.active>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <reloader.use-h2-external>${reloader.use-h2-external}</reloader.use-h2-external>
+                                <external-db.allow-writes>${external-db.allow-writes}</external-db.allow-writes>
+                                <spring.profiles.active>${spring.profiles.active}</spring.profiles.active>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>external-oracle</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <!-- Use the real external DB (Oracle) for integration or manual tests. This profile does NOT
+                     supply credentials; pass them via -D or environment variables or use your usual secret store. -->
+                <reloader.use-h2-external>false</reloader.use-h2-external>
+                <external-db.allow-writes>true</external-db.allow-writes>
+                <external.db.vendor>oracle</external.db.vendor>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <reloader.use-h2-external>${reloader.use-h2-external}</reloader.use-h2-external>
+                                <external-db.allow-writes>${external-db.allow-writes}</external-db.allow-writes>
+                                <external.db.vendor>${external.db.vendor}</external.db.vendor>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/backend/scripts/seed_external_h2.sh
+++ b/backend/scripts/seed_external_h2.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Seed a local H2 database with the external queue table/sequence used by tests
+# Usage:
+#   ./seed_external_h2.sh           # creates ./external-h2-db.mv.db and seeds it with backend/src/main/resources/external_h2_seed.sql
+#   DB_URL=jdbc:h2:./mydb ./seed_external_h2.sh
+#   DB_FILE=./mydb ./seed_external_h2.sh
+# This script will attempt to locate the H2 jar in the local Maven repository; if not found it will download dependencies.
+
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SQL_FILE="$REPO_ROOT/src/main/resources/external_h2_seed.sql"
+DB_URL=${DB_URL:-jdbc:h2:./external-h2-db}
+
+# Try to locate h2 jar in local maven repo
+# Try to find H2 jar in the local maven repo first (~/.m2/repository)
+H2_JAR_FILE=$(ls -1 ~/.m2/repository/com/h2database/h2/*/h2-*.jar 2>/dev/null | sort -V | tail -n1 || true)
+
+if [ -z "${H2_JAR_FILE}" ]; then
+  echo "H2 jar not found in ~/.m2/repository; fetching dependency to $REPO_ROOT/target/dependency..."
+  (cd "$REPO_ROOT" && mvn dependency:copy-dependencies -DincludeGroupIds=com.h2database -DoutputDirectory=target/dependency)
+  # pick the first matching jar in the copied dependencies
+  H2_JAR_FILE=$(ls -1 "$REPO_ROOT/target/dependency"/h2-*.jar 2>/dev/null | sort -V | tail -n1 || true)
+fi
+
+if [ ! -f "$H2_JAR_FILE" ]; then
+  echo "Failed to locate h2 jar; looked for: $H2_JAR_FILE"
+  exit 1
+fi
+
+if [ ! -f "$SQL_FILE" ]; then
+  echo "SQL seed file not found: $SQL_FILE"
+  exit 1
+fi
+
+echo "Seeding H2 DB at $DB_URL using SQL $SQL_FILE"
+java -cp "$H2_JAR_FILE" org.h2.tools.RunScript -url "$DB_URL" -script "$SQL_FILE" -user SA -password ""
+
+echo "Seed complete. DB file(s) created in current directory (or in H2's storage)."
+
+echo "You can inspect it with the H2 console: java -cp $H2_JAR_FILE org.h2.tools.Console -url $DB_URL -user SA -password ''"


### PR DESCRIPTION
## Summary

Add a small H2 seed helper script and a README entry to document how to seed a local H2 "external" DB used by tests.

## Changes

- Add `backend/scripts/seed_external_h2.sh` — convenience script that locates an H2 jar (local Maven cache or project dependency fallback) and runs `org.h2.tools.RunScript` against `backend/src/main/resources/external_h2_seed.sql`.
- Update `backend/README-DEV.md` — add "Seed helper script" section (path, default DB URL, one-line usage example, brief notes about how the script works).
- Minor `backend/pom.xml` edits included in the branch.

## Checklist for reviewers

- [ ] Confirm the seed script path and default DB URL are acceptable.
- [ ] Verify the seed script does not accidentally commit DB artifacts (the repo intentionally keeps `external-h2-db.*` out of source control).
- [ ] Run the seed script locally and ensure it creates `external-h2-db.mv.db` and that `mvn -f backend/pom.xml -DskipITs=true test` passes with the test flags shown below.

## How to test locally

From the repository root:

```bash
bash backend/scripts/seed_external_h2.sh
RELOADER_USE_H2_EXTERNAL=true EXTERNAL_DB_ALLOW_WRITES=true mvn -f backend/pom.xml -DskipITs=true test
```

## Notes

- This PR is documentation and dev-tooling only.
