### PR TITLE
feat(frontend): lazy-load stepper + loading spinner

### DIFF
--- a/frontend/src/app/api/backend.service.ts
+++ b/frontend/src/app/api/backend.service.ts
@@ -56,4 +56,9 @@ export class BackendService {
   enqueue(senderId: number, req: EnqueueRequest){
     return this.http.post(`${this.base}/senders/${senderId}/enqueue`, req);
   }
+
+  getQueue(senderId: number, status: string = 'NEW', limit: number = 100) {
+    const params = new HttpParams().set('status', status).set('limit', String(limit));
+    return this.http.get<any[]>(`${this.base}/senders/${senderId}/queue`, { params });
+  }
 }

--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -39,3 +39,21 @@ button:disabled {
 .result-card {
   margin-top: 16px;
 }
+
+.stepper-skeleton {
+  margin-bottom: 12px;
+}
+.skeleton-line {
+  height: 12px;
+  background: linear-gradient(90deg, #eee 25%, #f5f5f5 50%, #eee 75%);
+  background-size: 200% 100%;
+  animation: loading 1.2s linear infinite;
+  margin: 8px 0;
+}
+.skeleton-line.short { width: 140px; }
+.skeleton-line.half { width: 50%; }
+
+@keyframes loading {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -10,6 +10,11 @@
 </mat-toolbar>
 
 <div class="app-container">
+  <div style="margin-bottom:12px; display:flex; align-items:center; gap:8px;">
+    <button mat-stroked-button type="button" (click)="loadStepper()" *ngIf="!stepperLoaded" [disabled]="stepperLoading">Load Stepper</button>
+    <mat-progress-spinner *ngIf="stepperLoading" diameter="20" mode="indeterminate"></mat-progress-spinner>
+  </div>
+  <ng-template #stepperHost></ng-template>
   <mat-card>
     <form (ngSubmit)="runNow()">
       <mat-form-field appearance="fill" class="full-width">

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -15,6 +15,18 @@
     <mat-progress-spinner *ngIf="stepperLoading" diameter="20" mode="indeterminate"></mat-progress-spinner>
   </div>
   <ng-template #stepperHost></ng-template>
+  <div *ngIf="stepperLoading" class="stepper-skeleton">
+    <mat-card>
+      <mat-card-title>
+        <div class="skeleton-line short"></div>
+      </mat-card-title>
+      <mat-card-content>
+        <div class="skeleton-line"></div>
+        <div class="skeleton-line"></div>
+        <div class="skeleton-line half"></div>
+      </mat-card-content>
+    </mat-card>
+  </div>
   <mat-card>
     <form (ngSubmit)="runNow()">
       <mat-form-field appearance="fill" class="full-width">

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -20,6 +20,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { LoginComponent } from './auth/login.component';
+import { ViewChild, ViewContainerRef } from '@angular/core';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { AuthInterceptor } from './auth/auth.interceptor';
 
@@ -47,6 +48,11 @@ import { AuthInterceptor } from './auth/auth.interceptor';
   styleUrls: ['./app.css']
 })
 export class App implements OnInit {
+
+  @ViewChild('stepperHost', { read: ViewContainerRef, static: true }) stepperHost!: ViewContainerRef;
+  stepperLoaded = false;
+  stepperLoading = false;
+
 
   sites: string[] = [];
   selectedSite: string = '';
@@ -89,6 +95,21 @@ export class App implements OnInit {
       if (id) this.fetchExternalLocations();
       else this.externalLocations = [];
     });
+  }
+
+  async loadStepper() {
+    if (this.stepperLoaded) return;
+    this.stepperLoading = true;
+    try {
+      // dynamic import to lazy-load the stepper bundle
+      const m = await import('./stepper/stepper.component');
+      const cmp = m.StepperComponent;
+      this.stepperHost.clear();
+      this.stepperHost.createComponent(cmp);
+      this.stepperLoaded = true;
+    } finally {
+      this.stepperLoading = false;
+    }
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/stepper/stepper.component.css
+++ b/frontend/src/app/stepper/stepper.component.css
@@ -1,0 +1,2 @@
+.stepper-card { padding: 12px; margin-bottom: 16px; }
+.full-width { width: 100%; }

--- a/frontend/src/app/stepper/stepper.component.html
+++ b/frontend/src/app/stepper/stepper.component.html
@@ -1,0 +1,100 @@
+<mat-card class="stepper-card">
+  <div *ngIf="step === 1">
+    <h3>1. Provide connection and filter</h3>
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Connection Key (optional)</mat-label>
+      <input matInput [(ngModel)]="connectionKey" name="connectionKey" />
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Saved Location ID (optional)</mat-label>
+      <input matInput type="number" [(ngModel)]="locationId" name="locationId" />
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Metadata location (required)</mat-label>
+      <input matInput [(ngModel)]="metadataLocation" name="metadataLocation" />
+    </mat-form-field>
+
+    <div style="display:flex; gap:8px;">
+      <button mat-raised-button color="primary" (click)="doSearch()" [disabled]="!canSearch() || loading">Search</button>
+    </div>
+  </div>
+
+  <div *ngIf="step === 2">
+    <h3>2. Discovered results</h3>
+    <div *ngIf="loading"><mat-progress-spinner diameter="24" mode="indeterminate"></mat-progress-spinner> Searching...</div>
+    <div *ngIf="!loading && discovered && discovered.length === 0">No results</div>
+    <div *ngIf="senders && senders.length">
+      <mat-form-field appearance="fill" class="full-width">
+        <mat-label>Choose sender (for enqueue)</mat-label>
+        <mat-select [(ngModel)]="selectedSenderId" name="selectedSenderId">
+          <mat-option *ngFor="let s of senders" [value]="s.idSender">{{ s.idSender }} — {{ s.name }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div *ngIf="!loading && discovered && discovered.length">
+      <div style="display:flex; justify-content:flex-end; gap:8px; margin-bottom:8px;">
+        <button mat-button (click)="selectAll(sel)">Select all</button>
+        <button mat-button (click)="clearSelection(sel)">Clear</button>
+      </div>
+      <mat-selection-list #sel>
+        <mat-list-option *ngFor="let d of discovered" [value]="d">
+          <div style="display:flex; justify-content:space-between; align-items:center; width:100%;">
+            <div>{{ d.idSender || 'unknown' }} — {{ d.name }}</div>
+            <div><small>{{ d.extra || '' }}</small></div>
+          </div>
+        </mat-list-option>
+      </mat-selection-list>
+      <div style="display:flex; gap:8px; margin-top:8px;">
+        <button mat-button (click)="backToInputs()">Back</button>
+        <button mat-raised-button color="primary" (click)="submitSelectionFromList(sel.selectedOptions.selected)" [disabled]="!selectedSenderId">Enqueue selected</button>
+      </div>
+    </div>
+    <div style="display:flex; gap:8px; margin-top:8px;">
+      <button mat-button (click)="backToInputs()">Back</button>
+      <button mat-button color="primary" (click)="step = 3">Go to monitoring</button>
+    </div>
+  </div>
+
+  <div *ngIf="step === 3">
+    <h3>3. Monitoring</h3>
+    <div *ngIf="monitoringQueue && monitoringQueue.length === 0">No queue items found</div>
+
+    <!-- Enqueue response details card -->
+    <div *ngIf="enqueueResponse" style="margin-bottom:12px;">
+      <mat-card>
+        <mat-card-title>Enqueue result</mat-card-title>
+        <mat-card-content>
+          <div><strong>Enqueued:</strong> {{ enqueueResponse.enqueued != null ? enqueueResponse.enqueued : 'N/A' }}</div>
+          <div *ngIf="enqueueResponse.skipped && enqueueResponse.skipped.length">
+            <p><strong>Skipped ({{ enqueueResponse.skipped.length }}):</strong></p>
+            <mat-list>
+              <mat-list-item *ngFor="let sid of enqueueResponse.skipped">{{ sid }}</mat-list-item>
+            </mat-list>
+            <div style="margin-top:8px; display:flex; gap:8px; align-items:center;">
+              <button mat-button (click)="copySkippedToClipboard()">Copy Skipped IDs</button>
+              <button mat-button (click)="showFullResponse = !showFullResponse">{{ showFullResponse ? 'Hide' : 'Show' }} Full Response</button>
+            </div>
+            <mat-expansion-panel *ngIf="showFullResponse" style="margin-top:8px;">
+              <mat-expansion-panel-header>
+                <mat-panel-title>Full Enqueue Response</mat-panel-title>
+              </mat-expansion-panel-header>
+              <pre style="white-space:pre-wrap">{{ enqueueResponse | json }}</pre>
+            </mat-expansion-panel>
+          </div>
+          <div *ngIf="!enqueueResponse.skipped || enqueueResponse.skipped.length === 0"><small>No skipped payloads reported.</small></div>
+        </mat-card-content>
+      </mat-card>
+    </div>
+    <mat-card *ngFor="let q of monitoringQueue" style="margin-bottom:8px;">
+      <mat-card-content style="display:flex; justify-content:space-between; align-items:center;">
+        <div style="display:flex; gap:12px; align-items:center;">
+          <div>{{ q.id }} — {{ q.payloadId || q.id_data || q.id_metadata }}</div>
+          <mat-chip [color]="getStatusColor(q.status)" selected>{{ q.status }}</mat-chip>
+        </div>
+      </mat-card-content>
+    </mat-card>
+    <div style="margin-top:8px;"><button mat-button (click)="loadMonitoring()">Refresh</button></div>
+  </div>
+</mat-card>

--- a/frontend/src/app/stepper/stepper.component.ts
+++ b/frontend/src/app/stepper/stepper.component.ts
@@ -1,0 +1,159 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { BackendService } from '../api/backend.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatListModule } from '@angular/material/list';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+
+
+@Component({
+  selector: 'app-stepper',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatButtonModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatCardModule, MatProgressSpinnerModule, MatListModule, MatSnackBarModule, MatExpansionModule, MatChipsModule],
+  templateUrl: './stepper.component.html',
+  styleUrls: ['./stepper.component.css']
+})
+export class StepperComponent {
+  // stepper state: 1=inputs, 2=list, 3=monitor
+  step = 1;
+
+  // inputs
+  site = '';
+  environment = 'qa';
+  connectionKey = '';
+  locationId: number | null = null;
+  metadataLocation = '';
+
+  // results
+  discovered: Array<any> = [];
+  // available senders (from discovered results)
+  senders: Array<{idSender:number|null,name:string}> = [];
+  selectedSenderId: number | null = null;
+  loading = false;
+
+  // monitoring
+  monitoringQueue: Array<any> = [];
+  constructor(private api: BackendService, private snack: MatSnackBar, private clipboard: Clipboard) {}
+  enqueueResponse: { enqueued?: number; skipped?: string[] } | null = null;
+  private monitoringTimer: any = null;
+  showFullResponse = false;
+
+ 
+
+  canSearch(): boolean {
+    // require either connectionKey or locationId and metadataLocation
+    return (!!this.connectionKey || !!this.locationId) && !!this.metadataLocation;
+  }
+
+  doSearch() {
+    if (!this.canSearch()) return;
+    this.loading = true;
+    // reuse lookupSenders via BackendService: caller expects a senderId, but we'll call lookup with metadataLocation
+    this.api.lookupSenders({ connectionKey: this.connectionKey || undefined, locationId: this.locationId || undefined, metadataLocation: this.metadataLocation, environment: this.environment }).subscribe(
+      (data: any[]) => {
+        this.discovered = data || [];
+        // build senders list from discovered rows (unique idSender)
+        const seen = new Set<number>();
+        this.senders = [];
+        (this.discovered || []).forEach(d => {
+          const id = d.idSender || null;
+          if (id != null && !seen.has(id)) { seen.add(id); this.senders.push({ idSender: id, name: d.name }); }
+        });
+        this.selectedSenderId = this.senders.length ? this.senders[0].idSender : null;
+        this.loading = false;
+        this.step = 2;
+      },
+      (err: any) => { console.error('Search failed', err); this.loading = false; }
+    );
+  }
+
+  submitSelection() {
+    // collect selected payload ids (for demo we use discovered ids if present)
+    // kept for compatibility with old callers
+    this.submitSelectionFromList((this.discovered || []).map(d => ({ value: d } as any)) as any);
+  }
+
+  submitSelectionFromList(selected: any[]) {
+    const payloadIds = (selected || []).map(s => {
+      const d = s.value || s;
+      return String(d.idSender || d.name || d.id || d.payloadId || '');
+    }).filter((x: string) => !!x);
+    if (!payloadIds.length) { this.step = 3; this.loadMonitoring(); return; }
+    const req = { senderId: this.selectedSenderId, payloadIds: payloadIds, source: 'ui_stepper' } as any;
+    const sid = this.selectedSenderId || 0;
+    this.api.enqueue(sid, req).subscribe((resp: any) => {
+      // resp expected to be { enqueued: number, skipped: [ ... ] } (see backend dto)
+      const enq = resp && resp.enqueuedCount != null ? resp.enqueuedCount : (resp && resp.enqueued ? resp.enqueued : null);
+      const skipped = resp && resp.skippedPayloads ? resp.skippedPayloads : (resp && resp.skipped ? resp.skipped : []);
+      const enqNum = enq != null ? enq : (resp && resp.enqueued ? resp.enqueued : null);
+      const skippedArr = skipped || [];
+      this.enqueueResponse = { enqueued: enqNum, skipped: skippedArr };
+      const msg = `Enqueued ${enqNum != null ? enqNum : '?'}; skipped ${skippedArr.length}`;
+      this.snack.open(msg, 'OK', { duration: 4000 });
+      this.step = 3;
+      this.startMonitoringPoll();
+    }, (err: any) => { console.error('Enqueue failed', err); this.step = 3; this.loadMonitoring(); this.snack.open('Enqueue failed', 'Close', { duration: 5000 }); });
+  }
+
+  selectAll(sel: any) {
+    if (!sel) return;
+    sel.selectAll();
+  }
+
+  clearSelection(sel: any) {
+    if (!sel) return;
+    sel.deselectAll();
+  }
+
+  copySkippedToClipboard() {
+    if (!this.enqueueResponse || !this.enqueueResponse.skipped || !this.enqueueResponse.skipped.length) {
+      this.snack.open('No skipped IDs to copy', 'OK', { duration: 2000 });
+      return;
+    }
+    const text = this.enqueueResponse.skipped.join(',');
+    this.clipboard.copy(text);
+    this.snack.open('Skipped IDs copied to clipboard', 'OK', { duration: 2500 });
+  }
+
+  getStatusColor(status: string | null): 'primary' | 'accent' | 'warn' | undefined {
+    if (!status) return undefined;
+    const s = status.toUpperCase();
+    if (s === 'FAILED' || s === 'FAIL') return 'warn';
+    if (s === 'STAGED' || s === 'PUSHED' || s === 'PROCESSING') return 'accent';
+    return 'primary';
+  }
+
+  loadMonitoring() {
+    // For demonstration, call the queue endpoint for a selected sender (if any)
+    // We'll attempt to use a sender id from discovered list if present
+    const sid = this.discovered && this.discovered.length && this.discovered[0].idSender ? this.discovered[0].idSender : 0;
+    this.api.getQueue(sid, 'NEW', 200).subscribe((q: any[]) => { this.monitoringQueue = q || []; }, (err: any) => { console.error('Monitoring load failed', err); this.monitoringQueue = []; });
+  }
+
+  startMonitoringPoll(intervalMs: number = 3000) {
+    this.stopMonitoringPoll();
+    this.loadMonitoring();
+    this.monitoringTimer = setInterval(() => {
+      this.loadMonitoring();
+    }, intervalMs);
+  }
+
+  stopMonitoringPoll() {
+    if (this.monitoringTimer) { clearInterval(this.monitoringTimer); this.monitoringTimer = null; }
+  }
+
+  // ensure timer cleanup when user navigates back
+  backToInputs() { this.stopMonitoringPoll(); this.step = 1; }
+
+  
+}


### PR DESCRIPTION
Lazy-load the Stepper component to reduce initial bundle size and show a small spinner while the stepper chunk downloads. Files: app.ts, app.html, stepper component files. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a multi-step workflow to search, select, enqueue, and monitor items.
  * Added lazy-loaded Stepper UI with dynamic insertion and idempotent loading.
  * Enabled queue monitoring with manual refresh and periodic auto-polling.
  * Provided sender filtering, multi-select actions (select all/clear), and clipboard copy for skipped IDs.
  * Added loading indicators: header button state, progress spinner, and skeleton placeholder.

* **Style**
  * Added stepper layout utilities and full-width styles.
  * Implemented skeleton loading animations and variants for improved perceived performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->