### PR TITLE
chore(scripts): add PowerShell helpers for Windows dev

### DIFF
--- a/.github/workflows/windows-seed-test.yml
+++ b/.github/workflows/windows-seed-test.yml
@@ -1,0 +1,41 @@
+name: CI - Windows Maven + seed check
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'backend/scripts/**'
+      - '.github/workflows/**'
+
+jobs:
+  windows-seed:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Ensure Maven
+        run: choco install maven -y
+
+      - name: Show versions
+        run: |
+          java -version
+          mvn -version
+        shell: bash
+
+      - name: Run Maven tests
+        run: mvn -B -DskipTests=false test
+        working-directory: backend
+
+      - name: Run H2 seed PowerShell script (verify script runs)
+        shell: pwsh
+        run: |
+          # allow script execution for this session and run the seed helper
+          Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+          .\backend\scripts\seed_external_h2.ps1

--- a/.github/workflows/windows-seed-test.yml
+++ b/.github/workflows/windows-seed-test.yml
@@ -39,3 +39,10 @@ jobs:
           # allow script execution for this session and run the seed helper
           Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
           .\backend\scripts\seed_external_h2.ps1
+
+      - name: Upload backend jar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-jar
+          path: |
+            backend/target/*.jar

--- a/.github/workflows/windows-seed-test.yml
+++ b/.github/workflows/windows-seed-test.yml
@@ -6,6 +6,9 @@ on:
       - 'backend/**'
       - 'backend/scripts/**'
       - '.github/workflows/**'
+  push:
+    branches:
+      - main
 
 jobs:
   windows-seed:
@@ -46,3 +49,29 @@ jobs:
           name: backend-jar
           path: |
             backend/target/*.jar
+
+  full-tests:
+    # Run full tests only on main branch pushes
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
+
+      - name: Run full Maven tests
+        run: mvn -B -DskipTests=false test
+        working-directory: backend

--- a/.github/workflows/windows-seed-test.yml
+++ b/.github/workflows/windows-seed-test.yml
@@ -29,8 +29,8 @@ jobs:
           mvn -version
         shell: bash
 
-      - name: Run Maven tests
-        run: mvn -B -DskipTests=false test
+      - name: Run lightweight Maven package (skip tests)
+        run: mvn -B -DskipTests package
         working-directory: backend
 
       - name: Run H2 seed PowerShell script (verify script runs)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Build:
 mvn -f backend clean package
 ```
 
+Windows developers
+------------------
+
+If you're developing on Windows, the backend includes PowerShell helper scripts and a Windows usage section in `backend/README-DEV.md` (seed and predeploy helpers: `backend/scripts/seed_external_h2.ps1`, `backend/scripts/predeploy_check.ps1`). See that file for copy-paste examples to run the H2 seed helper and predeploy checks in PowerShell.
+
 Developer docs and runbooks for the backend are in `backend/docs/`. See `backend/docs/external-db-runbook.md` for details about external DB opt-in flags and testing guidance.
 
 Frontend

--- a/backend/README-DEV.md
+++ b/backend/README-DEV.md
@@ -332,3 +332,29 @@ If you'd like I can:
 - Add the quick helper script to seed H2 automatically (low-risk) under `backend/scripts/`.
 - Add a short pointer in the project's top-level `README.md` linking to this DEV doc.
 If you'd like I can also add a short badge or a targeted workflow that runs on PR to `main` once we're comfortable with the behavior.
+
+Windows (PowerShell) usage
+---------------------------
+
+If you're developing on Windows or prefer PowerShell, equivalents of the convenience scripts are provided in `backend/scripts/`:
+
+- `seed_external_h2.ps1` — PowerShell seed helper (same behavior as the shell script). Example usage (PowerShell):
+
+```powershell
+# From repository root (PowerShell)
+.\backend\scripts\seed_external_h2.ps1
+# You can set DB_URL in the session if you want a different file:
+$env:DB_URL='jdbc:h2:./mydb'; .\backend\scripts\seed_external_h2.ps1
+```
+
+- `predeploy_check.ps1` — PowerShell predeploy check wrapper. Example usage:
+
+```powershell
+.\backend\scripts\predeploy_check.ps1 -dbtype postgres -user dbuser -host dbhost -db reloaderdb
+```
+
+Notes:
+
+- These PowerShell scripts assume `psql` (for Postgres) or `sqlplus` (for Oracle) are available on your PATH if you invoke the predeploy check against those databases.
+- The PowerShell seed helper will attempt to locate H2 in `%USERPROFILE%\.m2\repository` and otherwise runs `mvn dependency:copy-dependencies` (so you need Maven and Java on PATH).
+- If you'd like, I can add `.ps1` examples to the top-level README and to CI docs.

--- a/backend/scripts/predeploy_check.ps1
+++ b/backend/scripts/predeploy_check.ps1
@@ -1,0 +1,54 @@
+<#
+PowerShell port of predeploy_check.sh
+Usage: .\predeploy_check.ps1 -dbtype <oracle|postgres> -user <user> -host <host> -db <db> [-dedupe] [-connect <connect-string>]
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][ValidateSet('oracle','postgres')][string]$dbtype,
+    [string]$user,
+    [string]$host,
+    [string]$db,
+    [switch]$dedupe,
+    [string]$connect
+)
+
+Set-StrictMode -Version Latest
+try {
+    $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+    if ($dbtype -eq 'postgres') {
+        if (-not $user -or -not $host -or -not $db) { throw "For postgres provide -user, -host and -db" }
+        $findSql = Join-Path $scriptDir 'find_duplicate_sender_queue.sql'
+        $dedupeSql = Join-Path $scriptDir 'dedupe_sender_queue_keep_lowest_id.sql'
+        Write-Host "Running duplicate check (postgres)..."
+        & psql -h $host -U $user -d $db -f $findSql
+        if ($dedupe) {
+            Write-Host "Running dedupe (postgres) — ensure you have a backup and run in maintenance window..."
+            $confirm = Read-Host "Type YES to continue"
+            if ($confirm -eq 'YES') {
+                & psql -h $host -U $user -d $db -c "BEGIN;" -f $dedupeSql -c "COMMIT;"
+                Write-Host "Dedupe completed."
+            } else { Write-Host "Aborted by user."; exit 1 }
+        }
+    } elseif ($dbtype -eq 'oracle') {
+        $findSql = Join-Path $scriptDir 'find_duplicate_sender_queue_oracle.sql'
+        $dedupeSql = Join-Path $scriptDir 'dedupe_sender_queue_oracle.sql'
+        if (-not $connect) { throw "For oracle provide -connect user/password@//host:port/SID via -connect" }
+        Write-Host "Running duplicate check (oracle)..."
+        & sqlplus -s $connect "@${findSql}"
+        if ($dedupe) {
+            Write-Host "Running dedupe (oracle) — ensure you have a backup and run in maintenance window..."
+            $confirm = Read-Host "Type YES to continue"
+            if ($confirm -eq 'YES') {
+                & sqlplus -s $connect "@${dedupeSql}"
+                Write-Host "Dedupe completed."
+            } else { Write-Host "Aborted by user."; exit 1 }
+        }
+    } else {
+        throw "Unsupported dbtype: $dbtype"
+    }
+    Write-Host "Pre-deploy check completed."
+} catch {
+    Write-Error $_.Exception.Message
+    exit 2
+}

--- a/backend/scripts/seed_external_h2.ps1
+++ b/backend/scripts/seed_external_h2.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+  Seed a local H2 database with the external queue table/sequence used by tests (PowerShell)
+
+Usage:
+  .\seed_external_h2.ps1               # creates .\external-h2-db.mv.db and seeds it with backend/src/main/resources/external_h2_seed.sql
+  $env:DB_URL='jdbc:h2:./mydb'; .\seed_external_h2.ps1
+  $env:DB_FILE='./mydb'; .\seed_external_h2.ps1
+
+This script attempts to locate the H2 jar in the local Maven repository; if not found it will run mvn to copy dependencies.
+#>
+
+param()
+
+Set-StrictMode -Version Latest
+try {
+    $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+    $repoRoot = Resolve-Path "$scriptDir/.."
+    $sqlFile = Join-Path $repoRoot 'src/main/resources/external_h2_seed.sql'
+    $dbUrl = if ($env:DB_URL) { $env:DB_URL } else { 'jdbc:h2:./external-h2-db' }
+
+    # Try to locate H2 jar in local maven repo (~/.m2/repository)
+    $m2 = Join-Path $env:USERPROFILE '.m2\repository\com\h2database\h2'
+    $h2Jar = Get-ChildItem -Path $m2 -Filter 'h2-*.jar' -Recurse -ErrorAction SilentlyContinue | Sort-Object Name | Select-Object -Last 1
+    if (-not $h2Jar) {
+        Write-Host "H2 jar not found in ~/.m2/repository; fetching dependency to $repoRoot/target/dependency..."
+        Push-Location $repoRoot
+        & mvn dependency:copy-dependencies -DincludeGroupIds=com.h2database -DoutputDirectory=target/dependency
+        Pop-Location
+        $depDir = Join-Path $repoRoot 'target/dependency'
+        $h2Jar = Get-ChildItem -Path $depDir -Filter 'h2-*.jar' -ErrorAction SilentlyContinue | Sort-Object Name | Select-Object -Last 1
+    }
+
+    if (-not $h2Jar) { throw "Failed to locate h2 jar." }
+    if (-not (Test-Path $sqlFile)) { throw "SQL seed file not found: $sqlFile" }
+
+    Write-Host "Seeding H2 DB at $dbUrl using SQL $sqlFile"
+    & java -cp $h2Jar.FullName org.h2.tools.RunScript -url $dbUrl -script $sqlFile -user SA -password ""
+
+    Write-Host "Seed complete. DB file(s) created in current directory (or in H2's storage)."
+    Write-Host "You can inspect it with the H2 console: java -cp $($h2Jar.FullName) org.h2.tools.Console -url $dbUrl -user SA -password ''"
+} catch {
+    Write-Error $_.Exception.Message
+    exit 1
+}


### PR DESCRIPTION
Adds PowerShell equivalents of seed_external_h2.sh and predeploy_check.sh and documents Windows usage in backend/README-DEV.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Windows PowerShell support for database pre-deploy validation and optional deduplication across PostgreSQL and Oracle, with confirmations and clear error handling.
  - Added a PowerShell utility to seed a local H2 database using the existing SQL seed, with automatic dependency resolution and progress feedback.

- Documentation
  - Expanded backend developer guide with Windows-specific usage instructions, examples, and notes for the new PowerShell workflows, aligning with existing shell guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->